### PR TITLE
fix: issue that fails step 3 workflow if branch is not created.

### DIFF
--- a/.github/workflows/3-foster-healthy-growth.yml
+++ b/.github/workflows/3-foster-healthy-growth.yml
@@ -34,12 +34,14 @@ jobs:
     steps:
       - name: Checkout branch - prepare-to-collaborate
         uses: actions/checkout@v4
+        continue-on-error: true
         with:
           path: prepare-to-collaborate
           ref: prepare-to-collaborate
 
       - name: Checkout branch - add-issue-templates
         uses: actions/checkout@v4
+        continue-on-error: true
         with:
           path: add-issue-templates
           ref: add-issue-templates


### PR DESCRIPTION
Add the `continue-on-error` flag to the checkout steps in Step 3.

Previously, if a user created one of the branches without creating the other, the workflow would fail during checkout.
This meant everyone would receive a misleading failed workflow on Step 3. If they ignored it and continue, the exercise would work. However, if an attentive user noticed the failed workflow, they may become confused.