### PR TITLE
chore: replace deprecated url for dev container image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Python 3",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:3.13",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "forwardPorts": [8000],
   "postCreateCommand": "bash ./.devcontainer/postCreate.sh",
   "customizations": {


### PR DESCRIPTION
Minor update to the development container configuration to update from a deprecated URL.