### PR TITLE
Add GitHub.copilot-chat to devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "vscode": {
       "extensions": [
         "GitHub.copilot",
+        "GitHub.copilot-chat",
         "ms-python.python",
         "ms-python.debugpy",
         "mongodb.mongodb-vscode"


### PR DESCRIPTION
This PR adds the GitHub.copilot-chat extension to the devcontainer configuration.