### PR TITLE
Update finish_exercise workflow to v0.9.3

### DIFF
--- a/.github/workflows/5-merge.yml
+++ b/.github/workflows/5-merge.yml
@@ -88,7 +88,7 @@ jobs:
   finish_exercise:
     name: Finish Exercise
     needs: [find_exercise, post_review_content]
-    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.6.0
+    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3
     with:
       issue-url: ${{ needs.find_exercise.outputs.issue-url }}
       exercise-title: "Introduction to Repository Management"


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Updated the `exercise-toolkit/finish_exercise` workflow to latest version `v0.9.3` which now will stop leading users to repository home for udpates after they completed the exercise. This is done conditionally now based on the `update-readme-with-congratulation` which this repository already set to `false`. This was done because we can't update the README since a ruleset to protect main branch was created as part of the exercise

Based on that setting now in `exercise-toolkit/finish_exercise@v0.9.3` the message will be adjusted to simply congratulate on finishing the exercise without linking back to repository home /README



### Changes
<!-- Describe the changes this pull request introduces. -->

This pull request updates the version of the `finish-exercise.yml` workflow used in the GitHub Actions configuration. The new version likely includes bug fixes or improvements from the upstream repository.

Workflow dependency update:

* Updated the `finish_exercise` job in `.github/workflows/5-merge.yml` to use `skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3` instead of `v0.6.0`.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
