### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In this exercise, you will:
 1. Communicate procedures to help guide collaborators.
 1. Assign responsibility of parts of the code to particular collaborators.
 1. Learn the difference between collaboration in a personal repository and organization repository.
-1. Establish ground rules to promote a health collaboration environment.
+1. Establish ground rules to promote a healthy collaboration environment.
 1. Establish a process for managing security updates.
 
 > [!IMPORTANT]


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `health collaboration environment` to `healthy collaboration environment` in the README.

Fixes #30

## Test plan
- static validation: `health collaboration environment` appeared 1 time(s) before replacement.
- static validation: `health collaboration environment` absent and `healthy collaboration environment` present after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
