### PR TITLE
docs: update step-4 instructions to use new repo tab names

### DIFF
--- a/.github/steps/4-prepare-for-the-inevitable.md
+++ b/.github/steps/4-prepare-for-the-inevitable.md
@@ -77,9 +77,9 @@ Now that the automated options are ready, let's create a guide for real-life hum
 
 1. Find the **Private vulnerability reporting** setting and verify it is `enabled`.
 
-1. At the top navigation, click the **Security** tab.
+1. At the top navigation, click the **Security and quality** tab.
 
-1. In the left navigation, click the **Policy** option.
+1. In the left navigation, select **Security policy**.
 
 1. Click the **Start setup** button. An editor will be started to create the file `SECURITY.md`.
 


### PR DESCRIPTION
### Summary

Update GitHub UI navigation instructions for the Security policy in Step 4, and changed wording the following instruction.

### Changes
<!-- Describe the changes this pull request introduces. -->
GitHub has updated its repository interface since when the step 4 instructions were written. This PR updates the instructions in Step 4 to accurately reflect the current UI navigation, preventing confusion for new learners. And also changed wording to match the previous instructions wording.

Modifications:
- Changed `"**Security** tab"` to `"**Security and quality** tab"`.
- Changed `"click the **Policy** option"` to `"select **Security policy**"`.

<!-- If there's an existing issue for your change, please link to it below next to "Closes". -->
Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected. **(Not applicable)**
- [x] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).